### PR TITLE
simplifications

### DIFF
--- a/scripts/addition.sh
+++ b/scripts/addition.sh
@@ -1,8 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-printf 'Enter the First Number: '
+echo -n 'Enter the First Number: '
 read -r a
-printf 'Enter the Second Number: '
+echo -n 'Enter the Second Number: '
 read -r b
-x=$((a+b))
-printf '%s\n' "$a + $b = $x"
+echo "$a + $b = $((a+b))"

--- a/scripts/addition.sh
+++ b/scripts/addition.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-echo 'Enter the First Number :'
-read a
-echo 'Enter the Second Number :'
-read b
-x=$(expr "$a" + "$b")
-echo $a + $b = $x
+printf 'Enter the First Number: '
+read -r a
+printf 'Enter the Second Number: '
+read -r b
+x=$((a+b))
+printf '%s\n' "$a + $b = $x"

--- a/scripts/affect.sh
+++ b/scripts/affect.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 arr=('-' '\' '|' '/')
 while true; do
 	for c in "${arr[@]}"; do
-		printf "\r %c " $c
+		echo -en "\r $c "
 		sleep .5
 	done
 done

--- a/scripts/archive-and-encrypt.sh
+++ b/scripts/archive-and-encrypt.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 name=$1
 path=$2
-tar -czvf "$name".tar.gz "$path"
+tar -czvf "$name.tar.gz" "$path"
 gpg -c "$name.tar.gz"
 rm -rf "$name.tar.gz"

--- a/scripts/archive-and-encrypt.sh
+++ b/scripts/archive-and-encrypt.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 name=$1
 path=$2
-tar -czvf $name.tar.gz $path 
-gpg -c $name.tar.gz
-rm -rf $name.tar.gz
+tar -czvf "$name".tar.gz "$path"
+gpg -c "$name.tar.gz"
+rm -rf "$name.tar.gz"

--- a/scripts/armstrong.sh
+++ b/scripts/armstrong.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
-printf "Enter A Number: "
+#!/usr/bin/env bash
+echo -n "Enter A Number: "
 read -r n
 arm=0
 temp=$n
-while [ $n -ne 0 ]; do
+while [ "$n" -ne 0 ]; do
 	r=$((n % 10))
 	arm=$((arm + r * r * r))
 	n=$((n / 10))

--- a/scripts/armstrong.sh
+++ b/scripts/armstrong.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
-echo "Enter A Number"
-read n
+#!/bin/sh
+printf "Enter A Number: "
+read -r n
 arm=0
 temp=$n
 while [ $n -ne 0 ]; do
-	r=$(expr $n % 10)
-	arm=$(expr $arm + $r \* $r \* $r)
-	n=$(expr $n / 10)
+	r=$((n % 10))
+	arm=$((arm + r * r * r))
+	n=$((n / 10))
 done
 echo $arm
-if [ $arm -eq $temp ]; then
+if [ $arm -eq "$temp" ]; then
 	echo "Armstrong"
 else
 	echo "Not Armstrong"

--- a/scripts/binary2decimal.sh
+++ b/scripts/binary2decimal.sh
@@ -1,20 +1,19 @@
-#!/bin/bash
-echo "Enter a number :"
-read Binary
-if [ $Binary -eq 0 ]; then
+#!/bin/sh
+printf "Enter a number: "
+read -r binary
+if [ "$binary" -eq 0 ]; then
 	echo "Enter a valid number "
 	return
 else
-	while [ $Binary -ne 0 ]; do
-		Bnumber=$Binary
-		Decimal=0
+	while [ "$binary" -ne 0 ]; do
+		decimal=0
 		power=1
-		while [ $Binary -ne 0 ]; do
-			rem=$(expr $Binary % 10)
-			Decimal=$((Decimal + (rem * power)))
+		while [ "$binary" -ne 0 ]; do
+			rem=$((binary % 10))
+			decimal=$((decimal + (rem * power)))
 			power=$((power * 2))
-			Binary=$(expr $Binary / 10)
+			binary=$((binary / 10))
 		done
-		echo " $Decimal"
+		echo " $decimal"
 	done
 fi

--- a/scripts/binary2decimal.sh
+++ b/scripts/binary2decimal.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-printf "Enter a number: "
+#!/usr/bin/env bash
+echo -n "Enter a number: "
 read -r binary
 if [ "$binary" -eq 0 ]; then
 	echo "Enter a valid number "

--- a/scripts/color.sh
+++ b/scripts/color.sh
@@ -1,20 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-DARKGRAY='\033[1;30m'
-RED='\033[0;31m'
-LIGHTRED='\033[1;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-PURPLE='\033[0;35m'
-LIGHTPURPLE='\033[1;35m'
-CYAN='\033[0;36m'
-WHITE='\033[1;37m'
-DEFAULT='\033[0m'
-
-COLORS=($DARKGRAY $RED $LIGHTRED $GREEN $YELLOW $BLUE $PURPLE $LIGHTPURPLE $CYAN $WHITE )
-
-for c in "${COLORS[@]}";do
-    printf "\r $c LOVE $DEFAULT "
-    sleep 1
+for c in 90 31 91 32 33 34 35 95 36 97 ;do
+	printf '\r \033[%sm LOVE \033[0m ' "$c"
+	sleep 1
 done

--- a/scripts/color.sh
+++ b/scripts/color.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-for c in 90 31 91 32 33 34 35 95 36 97 ;do
-	printf '\r \033[%sm LOVE \033[0m ' "$c"
+for c in 90 31 91 32 33 34 35 95 36 97; do
+	echo -en "\r \e[${c}m LOVE \e[0m "
 	sleep 1
 done

--- a/scripts/convertlowercase.sh
+++ b/scripts/convertlowercase.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-echo -n "Enter File Name : "
-read fileName
+printf "Enter File Name: "
+read -r file
 
-if [ ! -f $fileName ]; then
-	echo "Filename $fileName does not exists"
+if [ ! -f "$file" ]; then
+	echo "Filename $file does not exists"
 	exit 1
 fi
 
-tr '[A-Z]' '[a-z]' <$fileName >>small.txt
+tr '[:upper:]' '[:lower:]' <"$file" >>small.txt

--- a/scripts/convertlowercase.sh
+++ b/scripts/convertlowercase.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-printf "Enter File Name: "
+echo -n "Enter File Name: "
 read -r file
 
 if [ ! -f "$file" ]; then
@@ -8,4 +8,4 @@ if [ ! -f "$file" ]; then
 	exit 1
 fi
 
-tr '[:upper:]' '[:lower:]' <"$file" >>small.txt
+tr '[:upper:]' '[:lower:]' < "$file" >> small.txt

--- a/scripts/count-lines.sh
+++ b/scripts/count-lines.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 wc -l ./*

--- a/scripts/count-lines.sh
+++ b/scripts/count-lines.sh
@@ -1,9 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-for F in *
-do
-	if [[ -f $F ]]
-	then
-		echo $F: $(cat $F | wc -l)
-	fi
-done
+wc -l ./*

--- a/scripts/dec2hex.sh
+++ b/scripts/dec2hex.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env bash
 printf "0x%x\n" "$1"

--- a/scripts/dec2hex.sh
+++ b/scripts/dec2hex.sh
@@ -1,3 +1,2 @@
-#!/bin/bash
-
-printf "0x%x\n" $1
+#!/bin/sh
+printf "0x%x\n" "$1"

--- a/scripts/decimal2binary.sh
+++ b/scripts/decimal2binary.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for ((i = 32; i >= 0; i--)); do
-	r=$((2 ** $i))
+	r=$((2 ** i))
 	Probablity+=($r)
 done
 
@@ -11,7 +11,7 @@ done
 }
 
 echo -en "Decimal\t\tBinary\n"
-for input_int in $@; do
+for input_int; do
 	s=0
 	test ${#input_int} -gt 11 && {
 		echo "Support Upto 10 Digit number :: skiping \"$input_int\""
@@ -22,12 +22,12 @@ for input_int in $@; do
 
 	for n in ${Probablity[@]}; do
 
-		if [[ $input_int -lt ${n} ]]; then
+		if [[ $input_int -lt $n ]]; then
 			[[ $s == 1 ]] && printf "%d" 0
 		else
-			printf "%d" 1
+			echo -n 1
 			s=1
-			input_int=$(($input_int - ${n}))
+			input_int=$((input_int - n))
 		fi
 	done
 	echo -e

--- a/scripts/directorysize.sh
+++ b/scripts/directorysize.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-printf " Enter your directory: "
+echo -n "Enter your directory: "
 read -r x
 du -sh "$x"

--- a/scripts/directorysize.sh
+++ b/scripts/directorysize.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo " Enter your directory: "
-read x
+printf " Enter your directory: "
+read -r x
 du -sh "$x"

--- a/scripts/division.sh
+++ b/scripts/division.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-echo .Enter the First Number: .
+printf 'Enter the First Number: '
 read a
-echo .Enter the Second Number: .
+printf "Enter the Second Number: "
 read b
-echo "$a / $b = $(expr $a / $b)"
+echo "$a / $b = $((a / b))"

--- a/scripts/division.sh
+++ b/scripts/division.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-printf 'Enter the First Number: '
+echo -n 'Enter the First Number: '
 read a
-printf "Enter the Second Number: "
+echo -n "Enter the Second Number: "
 read b
 echo "$a / $b = $((a / b))"

--- a/scripts/encrypt.sh
+++ b/scripts/encrypt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "Welcome, I am ready to encrypt a file/folder for you"
 echo "currently I have a limitation, Place me to the same folder, where a file to be encrypted is present"

--- a/scripts/encrypt.sh
+++ b/scripts/encrypt.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Welcome, I am ready to encrypt a file/folder for you"
 echo "currently I have a limitation, Place me to the same folder, where a file to be encrypted is present"
 echo "Enter the Exact File Name with extension"
-read file
+read -r file
 # decryption command
 # gpg -d filename.gpg > filename
-gpg -c $file
+gpg -c "$file"
 echo "I have encrypted the file sucessfully..."
 echo "Now I will be removing the original file"
-rm -rf $file
+rm -rf "$file"

--- a/scripts/evenodd.sh
+++ b/scripts/evenodd.sh
@@ -1,8 +1,7 @@
-#!/bin/bash
-printf "Enter The Number:"
+#!/usr/bin/env bash
+echo -n "Enter The Number: "
 read -r n
-num=$((n % 2))
-if [ $num -eq 0 ]; then
+if [ $((n % 2)) -eq 0 ]; then
 	echo "is a Even Number"
 else
 	echo "is a Odd Number"

--- a/scripts/evenodd.sh
+++ b/scripts/evenodd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-echo "Enter The Number"
-read n
-num=$(expr $n % 2)
+printf "Enter The Number:"
+read -r n
+num=$((n % 2))
 if [ $num -eq 0 ]; then
 	echo "is a Even Number"
 else

--- a/scripts/factorial.sh
+++ b/scripts/factorial.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-printf "Enter The Number: "
+#!/usr/bin/env bash
+echo -n "Enter The Number: "
 read -r a
 fact=1
 while [ "$a" -ne 0 ]; do

--- a/scripts/factorial.sh
+++ b/scripts/factorial.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
-echo "Enter The Number"
-read a
+#!/bin/sh
+printf "Enter The Number: "
+read -r a
 fact=1
-while [ $a -ne 0 ]; do
-	fact=$(expr $fact \* $a)
-	a=$(expr $a - 1)
+while [ "$a" -ne 0 ]; do
+	fact=$((fact * a))
+	a=$((a - 1))
 done
 echo $fact

--- a/scripts/fibonacci.sh
+++ b/scripts/fibonacci.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 x=0; y=1; i=2
 while true; do
 	i=$((i + 1))
 	z=$((x + y))
-	printf %s "$z "
+	echo -n "$z "
 	x=$y
 	y=$z
 	sleep .5

--- a/scripts/fibonacci.sh
+++ b/scripts/fibonacci.sh
@@ -1,11 +1,10 @@
-#!/bin/bash
-x=0
-y=1
-i=2
-while true ; do
-	i=$(expr $i + 1)
-	z=$(expr $x + $y)
-	echo -n "$z "
+#!/bin/sh
+
+x=0; y=1; i=2
+while true; do
+	i=$((i + 1))
+	z=$((x + y))
+	printf %s "$z "
 	x=$y
 	y=$z
 	sleep .5

--- a/scripts/hello-world.sh
+++ b/scripts/hello-world.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env bash
 echo "Hello World!"

--- a/scripts/hello-world.sh
+++ b/scripts/hello-world.sh
@@ -1,3 +1,2 @@
-#!/bin/bash
-
-echo "Hello World !"
+#!/bin/sh
+echo "Hello World!"

--- a/scripts/hextodec.sh
+++ b/scripts/hextodec.sh
@@ -1,3 +1,2 @@
-#!/bin/bash
-
-printf "%d \n " $1
+#!/bin/sh
+printf "%d\n " "$1"

--- a/scripts/hextodec.sh
+++ b/scripts/hextodec.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env bash
 printf "%d\n " "$1"

--- a/scripts/list-dir.sh
+++ b/scripts/list-dir.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-list=($(ls))
+set -- *
 
-for f in "${list[@]}";do
-    echo $f
+for i; do
+	echo "$i"
 done

--- a/scripts/list-dir.sh
+++ b/scripts/list-dir.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -- *
 

--- a/scripts/lowercase.sh
+++ b/scripts/lowercase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-read -p "Enter String Uppercase : " i
-o=$(echo "$i" | tr '[:upper:]' '[:lower:]')
-echo $o
+#!/bin/sh
+printf "Enter String Uppercase: "
+read -r i
+echo "$i" | tr '[:upper:]' '[:lower:]'

--- a/scripts/lowercase.sh
+++ b/scripts/lowercase.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
-printf "Enter String Uppercase: "
+#!/usr/bin/env bash
+echo -n "Enter String Uppercase: "
 read -r i
 echo "$i" | tr '[:upper:]' '[:lower:]'

--- a/scripts/multiplication.sh
+++ b/scripts/multiplication.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
-printf "Enter the First Number: "
+#!/usr/bin/env bash
+echo -n "Enter the First Number: "
 read a
-printf "Enter the Second Number: "
+echo -n "Enter the Second Number: "
 read b
 echo "$a * $b = $((a * b))"

--- a/scripts/multiplication.sh
+++ b/scripts/multiplication.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
-echo .Enter the First Number: .
+#!/bin/sh
+printf "Enter the First Number: "
 read a
-echo .Enter the Second Number: .
+printf "Enter the Second Number: "
 read b
-echo "$a * $b = $(expr $a \* $b)"
+echo "$a * $b = $((a * b))"

--- a/scripts/prime.sh
+++ b/scripts/prime.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-printf "Enter Any Number: "
+#!/usr/bin/env bash
+echo -n "Enter Any Number: "
 read -r n
 i=1; c=1
 while [ $i -le "$n" ]; do

--- a/scripts/prime.sh
+++ b/scripts/prime.sh
@@ -1,17 +1,15 @@
-#!/bin/bash
-echo “Enter Any Number”
-read n
-i=1
-c=1
-while [ $i -le $n ]; do
-	i=$(expr $i + 1)
-	r=$(expr $n % $i)
-	if [ $r -eq 0 ]; then
-		c=$(expr $c + 1)
-	fi
+#!/bin/sh
+printf "Enter Any Number: "
+read -r n
+i=1; c=1
+while [ $i -le "$n" ]; do
+	i=$((i + 1))
+	r=$((n % i))
+	[ $r -eq 0 ] && c=$((c + 1))
 done
+
 if [ $c -eq 2 ]; then
-	echo “Prime”
+	echo "Prime"
 else
-	echo “Not Prime”
+	echo "Not Prime"
 fi

--- a/scripts/process.sh
+++ b/scripts/process.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 echo "Hello $USER"
 echo "Hey i am $USER and will be telling you about the current processes"
 echo "Running processes List"

--- a/scripts/process.sh
+++ b/scripts/process.sh
@@ -1,5 +1,5 @@
-#! /bin/bash
+#!/bin/sh
 echo "Hello $USER"
-echo "Hey i am" $USER "and will be telling you about the current processes"
+echo "Hey i am $USER and will be telling you about the current processes"
 echo "Running processes List"
 ps

--- a/scripts/random-emoji.sh
+++ b/scripts/random-emoji.sh
@@ -2,6 +2,6 @@
 
 while true; do
 	rand=$(shuf -i 2600-2700 -n 1)
-	echo -n -e '   \u'$rand
+	printf "   \u$rand"
 	sleep 1
 done

--- a/scripts/random-emoji.sh
+++ b/scripts/random-emoji.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while true; do
 	rand=$(shuf -i 2600-2700 -n 1)
-	printf "   \u$rand"
+	echo -en "   \u$rand"
 	sleep 1
 done

--- a/scripts/randomfile.sh
+++ b/scripts/randomfile.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Hello $USER"
-echo "$(uptime)" >>"$(date)".txt
+uptime >> "$(date)".txt
 echo "Your File is being saved to $(pwd)"

--- a/scripts/randomfile.sh
+++ b/scripts/randomfile.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "Hello $USER"
 uptime >> "$(date)".txt

--- a/scripts/rang-random.sh
+++ b/scripts/rang-random.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 shuf -i "$1-$2" -n 1

--- a/scripts/rang-random.sh
+++ b/scripts/rang-random.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
-shuf -i $1-$2 -n 1
+shuf -i "$1-$2" -n 1

--- a/scripts/read-menu.sh
+++ b/scripts/read-menu.sh
@@ -1,41 +1,32 @@
 #!/bin/bash
 # read-menu: a menu driven system information program
 clear
-echo "
+cat << EOF
 Please Select:
 
     1. Display System Information
     2. Display Disk Space
     3. Display Home Space Utilization
     0. Quit
-"
-read -p "Enter selection [0-3] > "
 
-if [[ $REPLY =~ ^[0-3]$ ]]; then
-	if [[ $REPLY == 0 ]]; then
-		echo "Program terminated."
-		exit
-	fi
-	if [[ $REPLY == 1 ]]; then
-		echo "Hostname: $HOSTNAME"
-		uptime
-		exit
-	fi
-	if [[ $REPLY == 2 ]]; then
-		df -h
-		exit
-	fi
-	if [[ $REPLY == 3 ]]; then
-		if [[ $(id -u) -eq 0 ]]; then
+EOF
+printf 'Enter selection [0-3]: '
+read -r sel
+
+case $sel in
+	0) echo "Program terminated.";;
+	1) echo "Hostname: $HOSTNAME"; uptime;;
+	2) df -h;;
+	3)
+		if [ "$UID" = 0 ]; then
 			echo "Home Space Utilization (All Users)"
 			du -sh /home/*
 		else
 			echo "Home Space Utilization ($USER)"
-			du -sh $HOME
+			du -sh "$HOME"
 		fi
-		exit
-	fi
-else
-	echo "Invalid entry." >&2
-	exit 1
-fi
+	;;
+	*)
+		echo "Invalid entry." >&2
+		exit 1
+esac

--- a/scripts/read-menu.sh
+++ b/scripts/read-menu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # read-menu: a menu driven system information program
 clear
 cat << EOF
@@ -10,7 +10,7 @@ Please Select:
     0. Quit
 
 EOF
-printf 'Enter selection [0-3]: '
+echo -n 'Enter selection [0-3]: '
 read -r sel
 
 case $sel in

--- a/scripts/substraction.sh
+++ b/scripts/substraction.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
-echo .Enter the First Number: .
-read a
-echo .Enter the Second Number: .
-read b
-x=$(($a - $b))
-echo $a - $b = $x
+#!/bin/sh
+printf "Enter the First Number: "
+read -r a
+printf "Enter the Second Number: "
+read -r b
+echo "$a - $b = $((a - b))"

--- a/scripts/substraction.sh
+++ b/scripts/substraction.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 printf "Enter the First Number: "
 read -r a
 printf "Enter the Second Number: "

--- a/scripts/table.sh
+++ b/scripts/table.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
-echo .Enter The Number upto which you want to Print Table: .
-read n
+#!/bin/sh
+printf "Enter The Number upto which you want to Print Table: "
+read -r n
 i=1
 while [ $i -ne 10 ]; do
-	i=$(expr $i + 1)
-	table=$(expr $i \* $n)
-	echo $table
+	i=$((i + 1))
+	table=$((i * n))
+	echo "$table"
 done

--- a/scripts/table.sh
+++ b/scripts/table.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-printf "Enter The Number upto which you want to Print Table: "
+#!/usr/bin/env bash
+echo -n "Enter The Number upto which you want to Print Table: "
 read -r n
 i=1
 while [ $i -ne 10 ]; do


### PR DESCRIPTION
don't use expr, [both POSIX and shellcheck warn against it](https://github.com/koalaman/shellcheck/wiki/SC2003)

use the more portable /bin/sh for some scripts instead of bash, which isn't always required to be in /bin, but most scripts here assume it is there anyway. For the most part, sh syntax works well with bash, but not the other way around. There isn't really a reason not to use it when you can.