### PR TITLE
Add check for ImageMagick installation before running script

### DIFF
--- a/scripts/thumbnail.sh
+++ b/scripts/thumbnail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if ! [ -x "$(command -v convert)" ]; then
+  echo 'Error: ImageMagick is not installed. Please install ImageMagick and try again.'
+  exit 1
+fi
 for i in *.jpg; do
     convert "$i" -thumbnail 400 "thumbs/$i";
 done;


### PR DESCRIPTION
- Added a check to ensure ImageMagick is installed before executing the script.
- If ImageMagick is not found, the script will exit with an error message.